### PR TITLE
Update TextFileSnapshotStore.cs

### DIFF
--- a/src/JKang.EventSourcing.Persistence.FileSystem/Snapshotting/TextFileSnapshotStore.cs
+++ b/src/JKang.EventSourcing.Persistence.FileSystem/Snapshotting/TextFileSnapshotStore.cs
@@ -52,6 +52,7 @@ namespace JKang.EventSourcing.Persistence.FileSystem.Snapshotting
             int latestVersion = Directory
                 .GetFiles(_options.Folder, "*.snapshot")
                 .Select(x => Path.GetFileNameWithoutExtension(x))
+                .Where(x => x.StartsWith(aggregateId.ToString(), StringComparison.InvariantCultureIgnoreCase))
                 .Select(x => x.Split('.').LastOrDefault())
                 .Select(x => int.TryParse(x, NumberStyles.Integer, CultureInfo.InvariantCulture, out int version) ? version : -1)
                 .Where(x => x <= maxVersion)


### PR DESCRIPTION
Fix bug so only relevant files are loaded from the filesystem to determine if snapshot should be loaded.

## Context
While loading an aggregate with `ignoreSnapshot: false` in the method `FindAggregateAsync(id, ignoreSnapshot, version)`, the `TextFileSnapshotStore` loads all files from the file system and checks if there is a file with a version larger than the version of the aggregate. If an other aggregate has a snapshot and the version is lower or equals the current version of the aggregate, the snapshot is considered as the snapshot for this aggregate.
The result of this faulty filtering, is that the program tries to load a non-existing file from the file system, and crashes.

This fix checks if the files in the snapshot store contains a snapshot for the correct aggregate.
#80 